### PR TITLE
explicit context options to prevent duplicate validation attempts

### DIFF
--- a/SharpHose/Nozzles/LDAP/LDAPNozzle.cs
+++ b/SharpHose/Nozzles/LDAP/LDAPNozzle.cs
@@ -284,7 +284,7 @@ namespace SharpHose.Nozzles.LDAP
             {
                 using (var context = GetPrincipalContext())
                 {
-                    return context.ValidateCredentials(username, password);
+                    return context.ValidateCredentials(username, password, ContextOptions.Negotiate | ContextOptions.Signing | ContextOptions.Sealing);
                 }
             });
         }


### PR DESCRIPTION
Partial fix for issue #9. Maybe a full fix?

The only remaining issue is I don't know if this will work properly if the `Negotiate | Singing | Sealing` context options fail and you need to use `SimpleBind | SecureSocketLayer`. I don't know if `SimpleBind | SecureSocketLayer` is more widely accepted or if it may be rejected.